### PR TITLE
feat: implementar tema dark com alternância e persistência

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,11 +11,28 @@
   --error: #dc2626;
   --bg: #f8fafc;
   --surface: #ffffff;
+  --surface-alt: #f8fafc;
+  --surface-hover: #e2e8f0;
   --border: #e2e8f0;
   --text: #1e293b;
   --text-muted: #64748b;
   --radius: 8px;
   --shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+  --copy-success-bg: #dcfce7;
+  --copy-error-bg: #fee2e2;
+}
+
+[data-theme="dark"] {
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-alt: #0f172a;
+  --surface-hover: #334155;
+  --border: #334155;
+  --text: #f1f5f9;
+  --text-muted: #94a3b8;
+  --shadow: 0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
+  --copy-success-bg: #14532d;
+  --copy-error-bg: #7f1d1d;
 }
 
 body {
@@ -28,8 +45,48 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 2rem 1rem 1.5rem;
+}
+
+#theme-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  min-height: unset;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: normal;
+}
+
+#theme-toggle:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+#theme-toggle .icon-sun {
+  display: none;
+}
+
+#theme-toggle .icon-moon {
+  display: block;
+}
+
+[data-theme="dark"] #theme-toggle .icon-sun {
+  display: block;
+}
+
+[data-theme="dark"] #theme-toggle .icon-moon {
+  display: none;
 }
 
 header h1 {
@@ -170,13 +227,13 @@ button:active {
 }
 
 #copy-btn {
-  background: #f1f5f9;
+  background: var(--surface-alt);
   color: var(--text);
   border: 1px solid var(--border);
 }
 
 #copy-btn:hover:not(:disabled) {
-  background: #e2e8f0;
+  background: var(--surface-hover);
 }
 
 #copy-btn:disabled {
@@ -191,7 +248,7 @@ button:active {
   font-size: 0.85rem;
   line-height: 1.7;
   resize: vertical;
-  background: #f8fafc;
+  background: var(--surface-alt);
 }
 
 .copy-message {
@@ -204,12 +261,12 @@ button:active {
 }
 
 .copy-message.success {
-  background: #dcfce7;
+  background: var(--copy-success-bg);
   color: var(--success);
 }
 
 .copy-message.error {
-  background: #fee2e2;
+  background: var(--copy-error-bg);
   color: var(--error);
 }
 

--- a/index.html
+++ b/index.html
@@ -6,10 +6,27 @@
   <meta name="description" content="Gere prompts reutilizáveis a partir de modelos para suas tarefas de desenvolvimento." />
   <title>Prompt Fiction</title>
   <link rel="stylesheet" href="css/style.css" />
+  <script>
+    (function () {
+      var saved = localStorage.getItem('theme');
+      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (saved === 'dark' || (!saved && prefersDark)) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
 </head>
 <body>
 
   <header>
+    <button id="theme-toggle" type="button" aria-label="Alternar para tema escuro">
+      <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      </svg>
+      <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+      </svg>
+    </button>
     <h1>Prompt Fiction</h1>
     <p>Gere prompts reutilizáveis a partir de modelos para suas tarefas.</p>
   </header>

--- a/js/app.js
+++ b/js/app.js
@@ -10,8 +10,42 @@ document.addEventListener("DOMContentLoaded", () => {
   const resultArea = document.getElementById("result");
   const copyMsg = document.getElementById("copy-message");
   const taskError = document.getElementById("task-error");
+  const themeToggle = document.getElementById("theme-toggle");
 
+  initTheme();
   loadTemplates();
+
+  themeToggle.addEventListener("click", toggleTheme);
+
+  function initTheme() {
+    const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+    updateToggleLabel(isDark);
+
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+      if (!localStorage.getItem("theme")) {
+        applyTheme(e.matches ? "dark" : "light");
+      }
+    });
+  }
+
+  function toggleTheme() {
+    const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+    const next = isDark ? "light" : "dark";
+    localStorage.setItem("theme", next);
+    applyTheme(next);
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    updateToggleLabel(theme === "dark");
+  }
+
+  function updateToggleLabel(isDark) {
+    themeToggle.setAttribute(
+      "aria-label",
+      isDark ? "Alternar para tema claro" : "Alternar para tema escuro"
+    );
+  }
 
   generateBtn.addEventListener("click", generatePrompt);
   copyBtn.addEventListener("click", copyPrompt);


### PR DESCRIPTION
Adiciona suporte a tema dark via variáveis CSS e atributo data-theme no elemento html. O tema é aplicado sem flash (FOUC) por meio de script inline no head, respeita a preferência do sistema (prefers-color-scheme) e persiste a escolha do usuário no localStorage.

Closes #2

https://claude.ai/code/session_01B6Fp62xYpdYqF3R4UY3bz2