### PR TITLE
fix: tema dark como padrão e corrige toggle no mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,9 @@ header {
   align-items: center;
   justify-content: center;
   font-weight: normal;
+  cursor: pointer;
+  touch-action: manipulation;
+  z-index: 10;
 }
 
 #theme-toggle:hover {
@@ -302,5 +305,11 @@ footer a:hover {
   #generate-btn,
   #copy-btn {
     width: 100%;
+  }
+
+  #theme-toggle {
+    right: 0.25rem;
+    width: 44px;
+    height: 44px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -9,8 +9,7 @@
   <script>
     (function () {
       var saved = localStorage.getItem('theme');
-      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (saved === 'dark' || (!saved && prefersDark)) {
+      if (saved !== 'light') {
         document.documentElement.setAttribute('data-theme', 'dark');
       }
     })();

--- a/js/app.js
+++ b/js/app.js
@@ -22,8 +22,8 @@ document.addEventListener("DOMContentLoaded", () => {
     updateToggleLabel(isDark);
 
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
-      if (!localStorage.getItem("theme")) {
-        applyTheme(e.matches ? "dark" : "light");
+      if (!localStorage.getItem("theme") && !e.matches) {
+        applyTheme("light");
       }
     });
   }


### PR DESCRIPTION
- Tema dark é agora o padrão independente de preferência do sistema
- Adiciona touch-action: manipulation para eliminar delay de 300ms no iOS
- Adiciona z-index: 10 para garantir que o botão fique acima de outros elementos
- No mobile, afasta o botão da borda (right: 0.25rem) e aumenta área de toque (44×44px)
- Listener de sistema só muda para light quando não há preferência salva

https://claude.ai/code/session_01RSjAyi1sz3SKVgjKmNgNgi