### PR TITLE
feat: adicionar template de issue para atividades (#7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/atividade.yml
+++ b/.github/ISSUE_TEMPLATE/atividade.yml
@@ -1,0 +1,65 @@
+name: "Nova atividade"
+description: "Template para abrir atividades e padronizar contexto de implementação"
+title: "[Atividade] "
+labels:
+  - atividade
+body:
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: Descreva o cenário e o problema a resolver.
+      placeholder: Qual é o contexto desta atividade?
+    validations:
+      required: true
+
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Objetivo
+      description: Explique claramente o resultado esperado.
+      placeholder: O que precisa ser implementado?
+    validations:
+      required: true
+
+  - type: textarea
+    id: criterios-aceite
+    attributes:
+      label: Critérios de aceite
+      description: Liste critérios objetivos para considerar a atividade concluída.
+      placeholder: |
+        - [ ] Critério 1
+        - [ ] Critério 2
+    validations:
+      required: true
+
+  - type: input
+    id: referencia
+    attributes:
+      label: Referências
+      description: Links de apoio (docs, Figma, issue relacionada, etc.).
+      placeholder: https://...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: tecnologia
+    attributes:
+      label: Tecnologia principal
+      options:
+        - Frontend
+        - Backend
+        - Fullstack
+        - Documentação
+        - Infraestrutura
+        - Outro
+    validations:
+      required: true
+
+  - type: textarea
+    id: observacoes
+    attributes:
+      label: Observações adicionais
+      description: Dependências, restrições ou informações extras.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Discussões"
+    url: "https://github.com/FabioCarlesso/prompt-finction/discussions"
+    about: "Use as discussões para perguntas gerais e ideias."

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ O novo modelo aparecerá automaticamente no dropdown da aplicação.
 
 ---
 
+
+## Template de Issue no GitHub
+
+O repositório inclui um template de issue para abertura de atividades em `.github/ISSUE_TEMPLATE/atividade.yml`.
+
+Esse template padroniza o preenchimento de:
+- contexto;
+- objetivo;
+- critérios de aceite;
+- referências;
+- tecnologia principal;
+- observações adicionais.
+
+Também foi incluído `.github/ISSUE_TEMPLATE/config.yml` para desabilitar issues em branco e direcionar dúvidas para Discussions.
+
+---
+
 ## Estrutura do projeto
 
 ```


### PR DESCRIPTION
### Motivation
- Padronizar a abertura de issues para atividades, garantindo que contexto, objetivo e critérios de aceite sejam informados e facilitando planejamento e execução.

### Description
- Adiciona o template de issue em YAML em `.github/ISSUE_TEMPLATE/atividade.yml` com campos para `contexto`, `objetivo`, `critérios de aceite`, `referências`, `tecnologia` e `observações`.
- Inclui `.github/ISSUE_TEMPLATE/config.yml` para desabilitar issues em branco e apontar dúvidas para GitHub Discussions.
- Atualiza `README.md` com uma seção explicando a existência e uso do novo template.

### Testing
- Executed `node --check js/app.js` and `node --check js/templates.js`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ce1a0f548328bf01a1ca281d3eb8)