### PR TITLE
Adiciona template para criação de issues no GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Publicado no GitHub Pages: [https://fabiocarlesso.github.io/prompt-finction](htt
 | `docs` | Documentação | Criação ou atualização de documentação |
 | `pr-review` | Review | Review de Pull Request |
 | `activity-implementation` | Desenvolvimento | Template completo para implementar atividade/issue com fluxo de contexto, execução, validação e finalização |
+| `github-issue` | Desenvolvimento | Criação de issue no GitHub com objetivo, contexto, escopo, critérios de aceite e validação |
 
 ---
 

--- a/js/templates/activityTemplates.js
+++ b/js/templates/activityTemplates.js
@@ -42,5 +42,72 @@ Finalização:
 **Tecnologia principal:** {{TECH}}
 
 **Observações:** {{NOTES}}`
+  },
+
+  "github-issue": {
+    label: "Criação de Issue no GitHub",
+    category: "Desenvolvimento",
+    content: `Crie uma issue no GitHub para o repositório:
+
+**Repositório:** {{LINK}}
+
+## Objetivo
+
+Criar uma issue clara, organizada e pronta para orientar o desenvolvimento da seguinte atividade:
+
+**Atividade:** {{TASK}}
+
+## Contexto
+
+{{NOTES}}
+
+## Tecnologia
+
+{{TECH}}
+
+## Requisitos da issue
+
+A issue deve conter:
+
+- Título claro e objetivo
+- Descrição do problema ou necessidade
+- Objetivo da atividade
+- Escopo da implementação
+- Critérios de aceite
+- Sugestão de validação/testes
+- Observações técnicas, se existirem
+- Labels sugeridas, se fizer sentido
+
+## Estrutura esperada da issue
+
+Use o seguinte formato:
+
+\`\`\`md
+## Objetivo
+
+Descrever de forma direta o que deve ser implementado, corrigido ou analisado.
+
+## Contexto
+
+Explicar o motivo da issue, cenário atual, problema identificado ou necessidade da funcionalidade.
+
+## Escopo
+
+- Item 1
+- Item 2
+- Item 3
+
+## Critérios de aceite
+
+- [ ] Critério objetivo e verificável
+- [ ] Critério objetivo e verificável
+- [ ] Critério objetivo e verificável
+
+## Validação
+
+- [ ] Executar testes automatizados, se existirem
+- [ ] Executar lint/build, se o projeto possuir
+- [ ] Validar manualmente o comportamento esperado
+\`\`\``
   }
 };


### PR DESCRIPTION
## Resumo

- Adiciona o modelo `github-issue` aos templates disponíveis na aplicação.
- Atualiza o README para documentar o novo modelo.

## Motivo

Permitir gerar prompts estruturados para criação de issues no GitHub, orientando objetivo, contexto, escopo, critérios de aceite, validação e labels sugeridas.

## Testes executados

- `node --input-type=module -e "import('./js/templates.js').then(({ templates }) => { if (!templates['github-issue']) process.exit(1); console.log(Object.keys(templates).join('\\n')); })"`
- Validação manual via Node do template `github-issue` com todos os campos preenchidos.
- Validação manual via Node do template `github-issue` apenas com `TASK` preenchido.
- `git diff --check`

Não há comandos de teste, lint ou build configurados no projeto.

## Arquivos principais alterados

- `js/templates/activityTemplates.js`
- `README.md`

Closes #7