### PR TITLE
Valida colisao de chaves ao mesclar templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export const meusTemplates = {
   }
 };
 
-// js/templates.js — adicione o import e inclua no objeto final
+// js/templates.js — adicione o import e inclua a coleção no array templateCollections
 import { developmentTemplates } from "./templates/developmentTemplates.js";
 import { qualityTemplates } from "./templates/qualityTemplates.js";
 import { documentationTemplates } from "./templates/documentationTemplates.js";
@@ -87,17 +87,27 @@ import { reviewTemplates } from "./templates/reviewTemplates.js";
 import { activityTemplates } from "./templates/activityTemplates.js";
 import { meusTemplates } from "./templates/meusTemplates.js";
 
-export const templates = {
-  ...developmentTemplates,
-  ...qualityTemplates,
-  ...documentationTemplates,
-  ...reviewTemplates,
-  ...activityTemplates,
-  ...meusTemplates
-};
+const templateCollections = [
+  { name: "developmentTemplates", templates: developmentTemplates },
+  { name: "qualityTemplates", templates: qualityTemplates },
+  { name: "documentationTemplates", templates: documentationTemplates },
+  { name: "reviewTemplates", templates: reviewTemplates },
+  { name: "activityTemplates", templates: activityTemplates },
+  { name: "meusTemplates", templates: meusTemplates }
+];
 ```
 
-O novo modelo aparecerá automaticamente no dropdown da aplicação.
+O novo modelo aparecerá automaticamente no dropdown da aplicação. A chave de cada template deve ser única; se duas coleções exportarem a mesma chave, a aplicação interrompe o carregamento com uma mensagem indicando as coleções em conflito.
+
+---
+
+## Testes
+
+Execute a suíte automatizada com:
+
+```sh
+npm test
+```
 
 ---
 

--- a/js/templates.js
+++ b/js/templates.js
@@ -4,10 +4,33 @@ import { documentationTemplates } from "./templates/documentationTemplates.js";
 import { reviewTemplates } from "./templates/reviewTemplates.js";
 import { activityTemplates } from "./templates/activityTemplates.js";
 
-export const templates = {
-  ...developmentTemplates,
-  ...qualityTemplates,
-  ...documentationTemplates,
-  ...reviewTemplates,
-  ...activityTemplates
-};
+const templateCollections = [
+  { name: "developmentTemplates", templates: developmentTemplates },
+  { name: "qualityTemplates", templates: qualityTemplates },
+  { name: "documentationTemplates", templates: documentationTemplates },
+  { name: "reviewTemplates", templates: reviewTemplates },
+  { name: "activityTemplates", templates: activityTemplates }
+];
+
+export function mergeTemplateCollections(collections) {
+  const mergedTemplates = {};
+  const sourceByKey = new Map();
+
+  collections.forEach(({ name, templates }) => {
+    Object.entries(templates).forEach(([key, template]) => {
+      if (Object.prototype.hasOwnProperty.call(mergedTemplates, key)) {
+        const previousSource = sourceByKey.get(key);
+        throw new Error(
+          `Template key collision: "${key}" is defined in "${previousSource}" and "${name}".`
+        );
+      }
+
+      mergedTemplates[key] = template;
+      sourceByKey.set(key, name);
+    });
+  });
+
+  return mergedTemplates;
+}
+
+export const templates = mergeTemplateCollections(templateCollections);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mergeTemplateCollections, templates } from "../js/templates.js";
+
+test("mergeTemplateCollections merges template collections without collisions", () => {
+  const result = mergeTemplateCollections([
+    {
+      name: "firstTemplates",
+      templates: {
+        first: { label: "Primeiro", category: "Teste", content: "Conteudo 1" }
+      }
+    },
+    {
+      name: "secondTemplates",
+      templates: {
+        second: { label: "Segundo", category: "Teste", content: "Conteudo 2" }
+      }
+    }
+  ]);
+
+  assert.deepEqual(Object.keys(result), ["first", "second"]);
+});
+
+test("mergeTemplateCollections rejects duplicate template keys", () => {
+  assert.throws(
+    () => mergeTemplateCollections([
+      {
+        name: "firstTemplates",
+        templates: {
+          duplicated: { label: "Primeiro", category: "Teste", content: "Conteudo 1" }
+        }
+      },
+      {
+        name: "secondTemplates",
+        templates: {
+          duplicated: { label: "Segundo", category: "Teste", content: "Conteudo 2" }
+        }
+      }
+    ]),
+    /Template key collision: "duplicated" is defined in "firstTemplates" and "secondTemplates"\./
+  );
+});
+
+test("templates exports all current template keys", () => {
+  assert.deepEqual(Object.keys(templates), [
+    "feature",
+    "refactor",
+    "bugfix",
+    "tests",
+    "docs",
+    "backend-review",
+    "frontend-review",
+    "pr-review",
+    "activity-implementation",
+    "github-issue"
+  ]);
+});


### PR DESCRIPTION
## Resumo

- Substitui o merge por spread em `js/templates.js` por uma funcao de merge validada.
- Interrompe o carregamento quando duas colecoes definem a mesma chave de template, indicando as colecoes em conflito.
- Adiciona testes automatizados para merge sem colisao, rejeicao de chaves duplicadas e exportacao dos templates atuais.
- Atualiza o README com a regra de chaves unicas e o comando de testes.

## Motivo

O merge anterior sobrescrevia silenciosamente templates com chaves duplicadas. A validacao explicita evita perda acidental de templates e facilita identificar a origem do conflito.

## Testes executados

- `npm test`
- `node --check js/templates.js && node --check js/app.js`

## Arquivos principais alterados

- `js/templates.js`
- `test/templates.test.js`
- `package.json`
- `README.md`

Closes #11