### PR TITLE
Add Java Spring Boot review template

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Publicado no GitHub Pages: [https://fabiocarlesso.github.io/prompt-finction](htt
 | `tests` | Qualidade | Criação de testes |
 | `docs` | Documentação | Criação ou atualização de documentação |
 | `pr-review` | Review | Review de Pull Request |
+| `java-spring-boot-review` | Review | Code review de aplicação Java Spring Boot |
 | `activity-implementation` | Desenvolvimento | Template completo para implementar atividade/issue com fluxo de contexto, execução, validação e finalização |
 | `github-issue` | Desenvolvimento | Criação de issue no GitHub com objetivo, contexto, escopo, critérios de aceite e validação |
 

--- a/js/templates/reviewTemplates.js
+++ b/js/templates/reviewTemplates.js
@@ -57,5 +57,25 @@ Verifique: acessibilidade, responsividade, performance, reutilização de compon
 ---
 
 Avalie: clareza do objetivo, qualidade do código, cobertura de testes, impacto em outras funcionalidades e conformidade com os critérios de aceite da issue relacionada.`
+  },
+
+  "java-spring-boot-review": {
+    label: "Review Java Spring Boot",
+    category: "Review",
+    content: `Realize o code review de uma aplicação Java Spring Boot descrita abaixo.
+
+**Contexto:** {{TASK}}
+
+**Branch / PR:** {{BRANCH}}
+
+**Link:** {{LINK}}
+
+**Tecnologia principal:** {{TECH}}
+
+**Observações:** {{NOTES}}
+
+---
+
+Verifique: arquitetura em camadas, uso correto de controllers, services e repositories, validação de entrada, tratamento de exceções, transações, segurança, configuração, observabilidade, performance, testes unitários e de integração, migrações de banco e aderência às convenções do Spring Boot.`
   }
 };

--- a/js/templates/reviewTemplates.js
+++ b/js/templates/reviewTemplates.js
@@ -62,20 +62,58 @@ Avalie: clareza do objetivo, qualidade do código, cobertura de testes, impacto 
   "java-spring-boot-review": {
     label: "Review Java Spring Boot",
     category: "Review",
-    content: `Realize o code review de uma aplicação Java Spring Boot descrita abaixo.
+    content: `Review the PR below in detail:
 
-**Contexto:** {{TASK}}
+PR: {{TASK}}
 
-**Branch / PR:** {{BRANCH}}
+Focus your review on the following areas:
+
+1. Documentation
+   - Check whether the documentation was properly updated.
+   - Validate if \`context.md\` is clear, complete, and aligned with the changes in the PR.
+   - Identify missing explanations, outdated information, or inconsistencies.
+
+2. Bugs and Edge Cases
+   - Look for possible bugs introduced by the changes.
+   - Identify unhandled edge cases.
+   - Verify null handling, invalid inputs, empty results, unexpected states, and error scenarios.
+
+3. Security
+   - Check for possible security vulnerabilities.
+   - Review authentication, authorization, data exposure, input validation, logging of sensitive data, and unsafe configurations.
+
+4. Performance
+   - Identify possible performance issues.
+   - Check for unnecessary database calls, inefficient loops, excessive memory usage, N+1 queries, and avoidable processing.
+
+5. Spring Boot Best Practices
+   - Verify if the implementation follows Spring Boot best practices.
+   - Review controller, service, repository, DTO, validation, exception handling, dependency injection, transaction management, and configuration patterns.
+
+6. Tests
+   - Check whether the PR includes enough tests.
+   - Identify missing unit, integration, or edge-case tests.
+   - Suggest improvements to test coverage where needed.
+
+7. Code Quality
+   - Review readability, maintainability, naming, separation of responsibilities, duplication, and consistency with the existing project structure.
+
+After reviewing, leave comments directly on the PR where appropriate.
+
+For each finding, use the following format:
+- Problem:
+- Why it matters:
+- Suggested improvement:
+- Severity: Low / Medium / High
+
+If no issue is found in a specific area, mention that it looks good.
+
+**Branch sugerida:** {{BRANCH}}
 
 **Link:** {{LINK}}
 
 **Tecnologia principal:** {{TECH}}
 
-**Observações:** {{NOTES}}
-
----
-
-Verifique: arquitetura em camadas, uso correto de controllers, services e repositories, validação de entrada, tratamento de exceções, transações, segurança, configuração, observabilidade, performance, testes unitários e de integração, migrações de banco e aderência às convenções do Spring Boot.`
+**Observações:** {{NOTES}}`
   }
 };

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -52,6 +52,7 @@ test("templates exports all current template keys", () => {
     "backend-review",
     "frontend-review",
     "pr-review",
+    "java-spring-boot-review",
     "activity-implementation",
     "github-issue"
   ]);


### PR DESCRIPTION
## Resumo
- Adiciona o template `java-spring-boot-review` na categoria Review.
- Atualiza a lista de modelos disponíveis no README.
- Atualiza o teste que valida as chaves exportadas dos templates.

## Motivo
Atende à issue #14, criando um template específico para review de aplicações Java Spring Boot com pontos de verificação alinhados ao ecossistema Spring.

## Testes executados
- `npm test`

## Arquivos principais alterados
- `js/templates/reviewTemplates.js`
- `test/templates.test.js`
- `README.md`

Closes #14