### PR TITLE
Adiciona botão para limpar campos do formulário

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Publicado no GitHub Pages: [https://fabiocarlesso.github.io/prompt-finction](htt
 4. Preencha os campos opcionais conforme necessário.
 5. Clique em **Gerar Prompt**.
 6. Clique em **Copiar** para copiar o resultado.
+7. Clique em **Limpar Campos** para resetar todos os campos e o resultado gerado.
 
 > **Atenção ao rodar localmente:** o projeto usa ES Modules (`type="module"`), que não funcionam via protocolo `file://`. Para rodar localmente, use um servidor HTTP:
 > ```
@@ -157,7 +158,7 @@ prompt-finction/
 
 - [ ] Salvar último modelo usado no `localStorage`
 - [ ] Histórico dos últimos prompts gerados
-- [ ] Botão "Limpar campos"
+- [x] Botão "Limpar campos"
 - [ ] Botão "Baixar como Markdown"
 - [ ] Modo claro/escuro
 - [ ] Busca por modelo

--- a/css/style.css
+++ b/css/style.css
@@ -244,6 +244,16 @@ button:active {
   cursor: not-allowed;
 }
 
+#clear-btn {
+  background: var(--surface-alt);
+  color: var(--error);
+  border: 1px solid var(--error);
+}
+
+#clear-btn:hover {
+  background: var(--copy-error-bg);
+}
+
 #result {
   width: 100%;
   min-height: 220px;
@@ -303,7 +313,8 @@ footer a:hover {
   }
 
   #generate-btn,
-  #copy-btn {
+  #copy-btn,
+  #clear-btn {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
       <div class="actions">
         <button id="generate-btn" type="button">Gerar Prompt</button>
         <button id="copy-btn" type="button" disabled>Copiar</button>
+        <button id="clear-btn" type="button">Limpar Campos</button>
       </div>
       <div class="field" style="margin-top: 1rem;">
         <textarea id="result" readonly placeholder="O prompt gerado aparecerá aqui..."></textarea>

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const copyMsg = document.getElementById("copy-message");
   const taskError = document.getElementById("task-error");
   const themeToggle = document.getElementById("theme-toggle");
+  const clearBtn = document.getElementById("clear-btn");
 
   initTheme();
   loadTemplates();
@@ -51,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   generateBtn.addEventListener("click", generatePrompt);
   copyBtn.addEventListener("click", copyPrompt);
+  clearBtn.addEventListener("click", clearForm);
 
   function loadTemplates() {
     Object.entries(templates).forEach(([key, tpl]) => {
@@ -103,6 +105,19 @@ document.addEventListener("DOMContentLoaded", () => {
       const ok = document.execCommand("copy");
       showCopyMessage(ok ? "Prompt copiado!" : "Não foi possível copiar. Selecione e copie manualmente.", !ok);
     });
+  }
+
+  function clearForm() {
+    taskInput.value = "";
+    branchInput.value = "";
+    linkInput.value = "";
+    techInput.value = "";
+    notesInput.value = "";
+    resultArea.value = "";
+    copyBtn.disabled = true;
+    taskError.style.display = "none";
+    copyMsg.style.display = "none";
+    taskInput.focus();
   }
 
   function showCopyMessage(msg, isError) {


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

- Adiciona botão "Limpar Campos" na seção de ações do formulário
- Ao clicar, todos os campos são resetados (tarefa, branch, link, tecnologia, observações)
- O resultado gerado e a mensagem de cópia também são limpos
- O botão de copiar volta ao estado desabilitado
- Foco retorna ao campo de tarefa após limpar

## Detalhes técnicos

- `index.html`: novo `<button id="clear-btn">` no bloco `.actions`
- `js/app.js`: função `clearForm()` conectada ao evento `click` do botão
- `css/style.css`: estilo com borda e texto em vermelho (`--error`), responsivo no mobile

## Plano de testes

- [x] Preencher todos os campos e gerar um prompt
- [x] Clicar em "Limpar Campos" e verificar que todos os inputs ficam vazios
- [x] Verificar que o resultado gerado é apagado
- [x] Verificar que o botão "Copiar" volta a ficar desabilitado
- [x] Verificar comportamento no mobile (botão ocupa largura total)
- [x] Executar `npm test` — todos os testes devem passar

Closes #16

https://claude.ai/code/session_01QGCcM121ibsQQz8pe3piwJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGCcM121ibsQQz8pe3piwJ)_