### PR TITLE
feat: validate brag-prompt template and fix integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Publicado no GitHub Pages: [https://fabiocarlesso.github.io/prompt-finction](htt
 | `java-spring-boot-review` | Review | Code review de aplicação Java Spring Boot |
 | `activity-implementation` | Desenvolvimento | Template completo para implementar atividade/issue com fluxo de contexto, execução, validação e finalização |
 | `github-issue` | Desenvolvimento | Criação de issue no GitHub com objetivo, contexto, escopo, critérios de aceite e validação |
+| `angular-review` | Review | Code review de PR Angular |
+| `brag-prompt` | Desenvolvimento | Organiza conquistas/atividades anotadas no WhatsApp em categorias (saúde, família, espiritual, estudo, lazer, profissional, financeiro) |
 
 ---
 
@@ -143,7 +145,9 @@ prompt-finction/
 │       ├── pr-review.js                    # Template: Review de Pull Request
 │       ├── java-spring-boot-review.js      # Template: Review Java Spring Boot
 │       ├── activity-implementation.js      # Template: Implementação de Atividade
-│       └── github-issue.js                 # Template: Criação de Issue no GitHub
+│       ├── github-issue.js                 # Template: Criação de Issue no GitHub
+│       ├── angular-review.js               # Template: Review Angular
+│       └── brag-prompt.js                  # Template: Brag prompt (organiza conquistas)
 ├── .nojekyll         # Desabilita processamento Jekyll no GitHub Pages
 └── README.md
 ```

--- a/js/templates/brag-prompt.js
+++ b/js/templates/brag-prompt.js
@@ -1,0 +1,30 @@
+export const bragPrompt = {
+  label: "Brag prompt",
+  category: "Desenvolvimento",
+  content: `Você é um assistente pessoal que ajuda a organizar conquistas diárias em categorias específicas.
+
+O usuário anotou no WhatsApp as atividades/conquistas.
+
+Organize o texto abaixo nas seguintes categorias (use EXATAMENTE esses nomes de chave):
+- saude: Saúde (exercícios, alimentação, bem-estar físico e mental)
+- familia: Família / Amigos / Colegas (relacionamentos, interações sociais)
+- espiritual: Espiritual / Gratidão (religião, meditação, gratidão, reflexões)
+- estudo: Estudo (aprendizado, cursos, leituras, inglês, etc.)
+- lazer: Lazer (diversão, descanso, hobbies, entretenimento)
+- profissional: Profissional (trabalho, projetos, realizações profissionais)
+- financeiro: Financeiro (economia, investimentos, gastos, conquistas financeiras)
+
+Texto do usuário:
+
+{{TASK}}
+
+Resposta:
+- Em uma lista de itens
+- Formato: Categoria - Texto
+- Caso tenha um texto parecido com "[12:20, 10/05/2026] Fabio Carlesso: ", remover
+
+Regras:
+- Preserve o conteúdo original, apenas organize e reformule se necessário para ficar mais claro
+- Cada item deve ser uma frase concisa descrevendo a conquista
+- Responda em português do Brasil`
+};

--- a/js/templates/index.js
+++ b/js/templates/index.js
@@ -10,12 +10,13 @@ import { javaSpringBootReview } from "./java-spring-boot-review.js";
 import { activityImplementation } from "./activity-implementation.js";
 import { githubIssue } from "./github-issue.js";
 import { angularReview } from "./angular-review.js";
+import { bragPrompt } from "./brag-prompt.js";
 
 export const templateCollections = [
   { name: "activityImplementation", templates: { "activity-implementation": activityImplementation } },  
   { name: "javaSpringBootReview", templates: { "java-spring-boot-review": javaSpringBootReview } },
   { name: "githubIssue", templates: { "github-issue": githubIssue } },
-  { name: "angularReview ", templates: { "angular-review ": angularReview } },
+  { name: "angularReview", templates: { "angular-review": angularReview } },
   { name: "feature", templates: { feature } },
   { name: "refactor", templates: { refactor } },
   { name: "bugfix", templates: { bugfix } },
@@ -23,5 +24,6 @@ export const templateCollections = [
   { name: "docs", templates: { docs } },
   { name: "backendReview", templates: { "backend-review": backendReview } },
   { name: "frontendReview", templates: { "frontend-review": frontendReview } },
-  { name: "prReview", templates: { "pr-review": prReview } }
+  { name: "prReview", templates: { "pr-review": prReview } },
+  { name: "bragPrompt", templates: { "brag-prompt": bragPrompt } }
 ];

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -14,6 +14,8 @@ import { prReview } from "../js/templates/pr-review.js";
 import { javaSpringBootReview } from "../js/templates/java-spring-boot-review.js";
 import { activityImplementation } from "../js/templates/activity-implementation.js";
 import { githubIssue } from "../js/templates/github-issue.js";
+import { angularReview } from "../js/templates/angular-review.js";
+import { bragPrompt } from "../js/templates/brag-prompt.js";
 
 const REQUIRED_FIELDS = ["label", "category", "content"];
 
@@ -58,6 +60,10 @@ test("mergeTemplateCollections rejects duplicate template keys", () => {
 
 test("templates exports all current template keys", () => {
   assert.deepEqual(Object.keys(templates), [
+    "activity-implementation",
+    "java-spring-boot-review",
+    "github-issue",
+    "angular-review",
     "feature",
     "refactor",
     "bugfix",
@@ -66,9 +72,7 @@ test("templates exports all current template keys", () => {
     "backend-review",
     "frontend-review",
     "pr-review",
-    "java-spring-boot-review",
-    "activity-implementation",
-    "github-issue"
+    "brag-prompt"
   ]);
 });
 
@@ -84,7 +88,9 @@ test("each individual template file has the required structure", () => {
     prReview,
     javaSpringBootReview,
     activityImplementation,
-    githubIssue
+    githubIssue,
+    angularReview,
+    bragPrompt
   ];
 
   for (const template of individualTemplates) {
@@ -102,7 +108,7 @@ test("each individual template file has the required structure", () => {
 });
 
 test("templateCollections index exports one collection per label", () => {
-  assert.equal(templateCollections.length, 11);
+  assert.equal(templateCollections.length, 13);
 
   for (const collection of templateCollections) {
     assert.ok(
@@ -135,4 +141,28 @@ test("adding a new valid template file makes it available in the merged template
 
   assert.ok(Object.prototype.hasOwnProperty.call(result, "new-template"));
   assert.deepEqual(result["new-template"], newTemplate);
+});
+
+test("brag-prompt template has expected metadata and content", () => {
+  assert.equal(bragPrompt.label, "Brag prompt");
+  assert.equal(bragPrompt.category, "Desenvolvimento");
+  assert.ok(bragPrompt.content.includes("{{TASK}}"), "content must reference the {{TASK}} variable");
+
+  const expectedCategories = [
+    "saude",
+    "familia",
+    "espiritual",
+    "estudo",
+    "lazer",
+    "profissional",
+    "financeiro"
+  ];
+  for (const key of expectedCategories) {
+    assert.ok(
+      bragPrompt.content.includes(`- ${key}:`),
+      `content must list category key "${key}"`
+    );
+  }
+
+  assert.ok(!/Respota/.test(bragPrompt.content), "content must not contain typo 'Respota'");
 });


### PR DESCRIPTION
## Resumo
- Validação do novo template `brag-prompt.js` recém-criado.
- Correção de typo `Respota` → `Resposta` no corpo do prompt.
- Correção da chave `"angular-review "` (espaço final) em `js/templates/index.js`, que ficou inconsistente em PR anterior.
- Atualização da suíte de testes para cobrir `brag-prompt` e `angular-review` (contagem de coleções, lista de chaves, validação de estrutura).
- Novo teste dedicado verificando metadata do `brag-prompt` (label, categoria, presença de `{{TASK}}` e das 7 categorias esperadas).
- README atualizado com os dois templates novos (tabela e árvore de estrutura).

## Motivo
O template `brag-prompt.js` foi adicionado mas:
1. continha um typo no texto;
2. não estava coberto por testes;
3. sua inclusão (junto com `angular-review`, também não testado) quebrou a suíte (`templateCollections.length` esperava 11 e havia 13).

## Testes executados
- `npm test` → 7/7 testes passando.

## Arquivos principais alterados
- `js/templates/brag-prompt.js` — fix typo
- `js/templates/index.js` — fix chave com espaço final em `angular-review`
- `test/templates.test.js` — atualização das asserções e novo teste para `brag-prompt`
- `README.md` — documenta `brag-prompt` e `angular-review`

## Referência
Atividade: validação do template `brag-prompt.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)